### PR TITLE
Fix Claude mode toggle: send real Shift+Tab and stop label flicker

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -725,12 +725,17 @@ class Nomacode {
     // every unrelated redraw, so ACCEPT/PLAN flickered straight back to NORMAL.
     let newMode = undefined;
 
-    if (clean.includes('plan mode on') || clean.includes('[plan]') || /\bplan\b.*mode\b/i.test(clean)) {
+    // Check the exit markers FIRST: "plan mode off" and "exited plan mode"
+    // both contain "plan mode", so an entry-first ordering claims them and the
+    // label sticks on PLAN forever. No loose /plan.*mode/ regex either — it
+    // matches ordinary prose like "I'll plan the refactor in normal mode",
+    // and Claude's own output is echoed to the terminal.
+    if (clean.includes('exited plan') || clean.includes('plan mode off') || clean.includes('accept edits off')) {
+      newMode = null;
+    } else if (clean.includes('plan mode on') || clean.includes('[plan]')) {
       newMode = 'PLAN';
     } else if (clean.includes('accept edits on') || clean.includes('autoaccept') || clean.includes('auto-accept') || clean.includes('[auto]')) {
       newMode = 'ACCEPT';
-    } else if (clean.includes('exited plan') || clean.includes('plan mode off') || clean.includes('accept edits off')) {
-      newMode = null;
     }
 
     if (newMode !== undefined && newMode !== this.claudeMode) {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -719,14 +719,17 @@ class Nomacode {
     // Strip ANSI escape codes for pattern matching
     const clean = data.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').toLowerCase();
 
-    // Detect mode changes from Claude Code status line
-    let newMode = null;
+    // Detect mode changes from Claude Code status line.
+    // Default is `undefined` = "this output chunk carries no mode info, leave
+    // the current label alone". Using `null` here reset the label to NORMAL on
+    // every unrelated redraw, so ACCEPT/PLAN flickered straight back to NORMAL.
+    let newMode = undefined;
 
-    if (clean.includes('plan mode') || clean.includes('[plan]') || /\bplan\b.*mode/i.test(clean)) {
+    if (clean.includes('plan mode on') || clean.includes('[plan]') || /\bplan\b.*mode\b/i.test(clean)) {
       newMode = 'PLAN';
-    } else if (clean.includes('autoaccept') || clean.includes('auto-accept') || clean.includes('[auto]')) {
+    } else if (clean.includes('accept edits on') || clean.includes('autoaccept') || clean.includes('auto-accept') || clean.includes('[auto]')) {
       newMode = 'ACCEPT';
-    } else if (clean.includes('exited plan') || clean.includes('plan mode off')) {
+    } else if (clean.includes('exited plan') || clean.includes('plan mode off') || clean.includes('accept edits off')) {
       newMode = null;
     }
 
@@ -811,12 +814,16 @@ class Nomacode {
   }
 
   cycleMode() {
-    // Iterate through: NORMAL → PLAN → ACCEPT → NORMAL
-    const modes = [null, 'PLAN', 'ACCEPT'];
-    const currentIdx = modes.indexOf(this.claudeMode);
-    const nextIdx = (currentIdx + 1) % modes.length;
-    this.claudeMode = modes[nextIdx];
-    this.updateClaudeModeDisplay();
+    // Actually cycle Claude Code's permission mode by sending a real
+    // Shift+Tab (backtab, ESC[Z) to the PTY. The displayed label is driven
+    // by parsing Claude's output in detectClaudeMode(), so we don't set it
+    // optimistically here (doing so just fought the parser and flickered
+    // back to NORMAL). This is also the only way to send Shift+Tab on mobile,
+    // where there's no physical Shift key.
+    const terminal = this.terminals.get(this.activeSessionId);
+    if (!terminal) return;
+    this.sendInput(this.activeSessionId, '\x1b[Z');
+    terminal.term.focus();
   }
 
   updateLogoCompact() {


### PR DESCRIPTION
## Problem

The status-bar mode button (`#status-mode` → `cycleMode()`) never actually changed Claude Code's permission mode — it only mutated the local `claudeMode` label. Two coupled bugs made the indicator "switch itself back to NORMAL":

1. **`cycleMode()` sent nothing to the PTY.** Tapping the button optimistically set the label (`null → PLAN → ACCEPT`) but never sent a keystroke, so Claude stayed in whatever mode it was in. On the next redraw the parser corrected the label back, which looked like the button flipping itself to NORMAL. On mobile this button is also the *only* way to send Shift+Tab, since the `TAB` toolbar key only emits `ESC[Z` when `shiftHeld` is true, and `shiftHeld` is set exclusively by a physical Shift key (absent on phones).

2. **`detectClaudeMode()` reset the label on every unrelated chunk.** `newMode` was initialized to `null`, so any output that didn't contain a "plan/accept" marker fell through and set the mode back to `null` (NORMAL). The ACCEPT/PLAN indicator flickered straight back to NORMAL on essentially every terminal redraw.

## Fix

- `cycleMode()` now sends `ESC[Z` (backtab / Shift+Tab) to the active session and lets the output parser drive the displayed label instead of setting it optimistically. This makes the button actually cycle Claude's mode (Normal → accept edits → plan) and gives mobile users a working Shift+Tab.
- `detectClaudeMode()` defaults `newMode` to `undefined` ("this chunk carries no mode info, leave the label alone"), so the indicator is only updated on an explicit signal. Also added Claude Code's current `accept edits on` / `accept edits off` wording to the ACCEPT / exit detection.

## Testing

Ran on Termux (Android, native, Claude Code 2.1.207) inside nomacode: tapping the mode button now cycles the real permission mode and the label tracks Claude's actual state instead of snapping back to NORMAL.

Diff is a single file (`web/js/app.js`), no dependency or build changes.