### PR TITLE
Fix tool detection on Termux: use command -v instead of which

### DIFF
--- a/server/services/tool-detector.js
+++ b/server/services/tool-detector.js
@@ -40,7 +40,10 @@ function commandExists(cmd, fastCheck = false) {
   }
 
   const isWindows = process.platform === 'win32';
-  const whichCmd = isWindows ? 'where' : 'which';
+  // `which` is not present on Termux (and not guaranteed on minimal Linux);
+  // `command -v` is a POSIX shell builtin that's always available. Using it
+  // fixes every tool showing as "not installed" on Termux.
+  const whichCmd = isWindows ? 'where' : 'command -v';
 
   try {
     // First check if command is in PATH


### PR DESCRIPTION
## Problem

On Termux, **every** tool (Claude Code, OpenCode, Codex) shows up as *not installed* and offers to install it, even when it's clearly on `PATH` and working.

## Root cause

`server/services/tool-detector.js` `commandExists()` runs `execSync('which <cmd>')`, but **Termux ships no `which` binary**. The call throws (exit 127), the outer `catch` returns `false`, so every tool is reported unavailable.

## Fix

Use `command -v` — a POSIX shell builtin that's always present — instead of `which` on non-Windows (`where` is kept on Windows).

## Verification

On Termux (native, arm64), with `claude` on `PATH`:

```
$ node -e "const {execSync}=require('child_process'); console.log(execSync('command -v claude').toString().trim())"
/data/data/com.termux/files/usr/bin/claude
```

`/api/tools` now correctly reports `claude-code` as `available: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
