### PR TITLE
Fix PTY detection on systems without a `which` binary

### DIFF
--- a/server/services/pty-manager.js
+++ b/server/services/pty-manager.js
@@ -22,7 +22,10 @@ for (const pkg of ptyPackages) {
 if (ptyMethod !== 'node-pty') {
   // Check if 'script' command is available (Unix only)
   if (os.platform() !== 'win32') {
-    const result = spawnSync('which', ['script'], { encoding: 'utf8' });
+    // Probe via `sh -c 'command -v'` rather than the `which` binary: Termux
+    // ships no `which`, so spawnSync would fail with ENOENT (status null) and
+    // silently drop to the no-PTY path even when `script` is installed.
+    const result = spawnSync('sh', ['-c', 'command -v script'], { encoding: 'utf8' });
     if (result.status === 0 && result.stdout.trim()) {
       ptyMethod = 'script';
       console.log('[pty-manager] Using script command for PTY');


### PR DESCRIPTION
## Problem

Follow-up to #7. That PR fixed `which` → `command -v` in `tool-detector.js`, but `server/services/pty-manager.js:25` carried the same dependency and was missed:

```js
const result = spawnSync('which', ['script'], { encoding: 'utf8' });
if (result.status === 0 && result.stdout.trim()) {
```

This one is worse than the tool-detector case. It uses `spawnSync` with an **argv array**, so no shell is involved and `command -v` cannot simply be swapped in — it's a builtin, not a binary.

On Termux there is no `which` binary, so `spawnSync` fails with `ENOENT` and sets `status` to `null`, not a non-zero exit code:

```
status: null   error: ENOENT
would take script path? NO -> falls back to direct spawn
```

Because the guard tests `status === 0`, an ENOENT is indistinguishable from "`script` is not installed". The PTY layer silently downgrades to direct spawn — **no PTY** — even when `script` is present. That's a degraded terminal on nomacode's primary target platform, and it fails quietly.

## Fix

Probe through `sh -c 'command -v script'`, so the lookup goes via a POSIX builtin that is always available.

## Verification

```
present binary (sh): DETECTED /usr/bin/sh
absent binary:       correctly absent
```

Detects binaries that exist, no false positives on missing ones.

Note: this machine is not Termux and has no `script` installed, so the ENOENT path was reproduced by simulating a missing lookup binary rather than observed on-device. Worth a confirmation run on Termux.