### PR TITLE
Add Enter and Backspace keys to the mobile toolbar

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -478,6 +478,15 @@ body.keyboard-visible #main-content {
   color: var(--bg);
 }
 
+/* Enter is the most-used key on a soft keyboard that swallows its own
+   Return, so give it a wider target and accent it as the primary action. */
+.key-btn-enter {
+  min-width: 60px;
+  border-color: var(--accent);
+  color: var(--accent);
+  font-size: 15px;
+}
+
 .toolbar-sep {
   width: 1px;
   height: 24px;

--- a/web/index.html
+++ b/web/index.html
@@ -92,6 +92,9 @@
       <button class="key-btn" data-key="ArrowDown">↓</button>
       <button class="key-btn" data-key="ArrowLeft">←</button>
       <button class="key-btn" data-key="ArrowRight">→</button>
+      <span class="toolbar-sep"></span>
+      <button class="key-btn" data-key="Backspace" aria-label="Backspace">⌫</button>
+      <button class="key-btn key-btn-enter" data-key="Enter" aria-label="Enter">⏎</button>
     </div>
 
     <!-- Status Bar -->

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1954,6 +1954,14 @@ class Nomacode {
         // Shift+Tab sends backtab escape sequence
         data = this.shiftHeld ? '\x1b[Z' : '\t';
         break;
+      case 'Enter':
+        // Carriage return, not \n: terminals submit on CR. Without this case
+        // the default branch would send the literal string "Enter".
+        data = '\r';
+        break;
+      case 'Backspace':
+        data = '\x7f';
+        break;
       case 'ArrowUp':
         data = '\x1b[A';
         break;


### PR DESCRIPTION
Fixes #5.

## Problem

The reporter has no physical keyboard, and their Android soft keyboard's Return does nothing in the terminal — leaving no way to submit a command. Their suggested fix was to add an Enter button, which is right: the toolbar had ESC, CTRL, ALT, TAB and arrows, but no Enter.

## The part that isn't obvious

Adding the button alone would not have worked. `sendKey()` had no `'Enter'` case, so it fell through to the `default` branch:

```js
} else {
  data = key;   // sends the literal string "Enter"
}
```

A button wired to `data-key="Enter"` would have typed the word *Enter* into the terminal. The handler case is the actual fix; the button is the UI for it.

Enter emits `\r` (carriage return) rather than `\n` — terminals submit on CR.

## Changes

- `sendKey()`: add `Enter` → `\r` and `Backspace` → `\x7f` (DEL, which is what terminals expect, not `\b`)
- `index.html`: add both buttons after a separator
- `style.css`: `.key-btn-enter` gets a wider target (60px) and the accent color, since it's the primary action

Backspace is included because it fails the same way on a soft keyboard that swallows its own key events, and it was equally missing.

## Verification

Extracted the real `sendKey` from `app.js` and drove it directly:

```
PASS Enter      sent "\r"
PASS Backspace  sent "\x7f"
PASS Escape     sent "\x1b"
PASS Tab        sent "\t"
PASS ArrowUp    sent "\x1b[A"
PASS ArrowDown  sent "\x1b[B"
PASS Enter not literal string
PASS Ctrl+C -> "\x03"
```

Existing keys and Ctrl+combinations are unregressed.

Not verified on-device — the underlying soft-keyboard behaviour can't be reproduced on desktop. Worth a confirmation from the reporter.