### PR TITLE
Port tmux session durability and resumable conversations from nomacode-RE

### DIFF
--- a/server/api/sessions.js
+++ b/server/api/sessions.js
@@ -5,6 +5,7 @@ const ptyManager = require('../services/pty-manager');
 const repoManager = require('../services/repo-manager');
 const toolDetector = require('../services/tool-detector');
 const { resolveProfileEnv } = require('./profiles');
+const conversations = require('../services/conversations');
 
 // List all sessions
 router.get('/', (req, res) => {
@@ -16,10 +17,22 @@ router.get('/', (req, res) => {
   }
 });
 
+// List past Claude conversations (resumable via `claude --resume <id>`).
+// Must be declared before GET '/:id' so it isn't swallowed as an id.
+router.get('/conversations', (req, res) => {
+  try {
+    // Don't offer to resume a conversation that's already live in a session.
+    const live = ptyManager.getAllSessions().map(s => s.id);
+    res.json(conversations.listConversations({ excludeIds: live }));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Create new session
 router.post('/', (req, res) => {
   try {
-    const { repoId, tool, cols, rows, profileId } = req.body;
+    const { repoId, tool, cols, rows, profileId, resumeId, cwd: resumeCwd } = req.body;
 
     // Validate tool exists in our list (but skip slow availability re-check)
     // The frontend already shows only available tools, and if the tool
@@ -54,6 +67,18 @@ router.post('/', (req, res) => {
       }
     }
 
+    // Resuming a past Claude conversation: launch `claude --resume <id>` from
+    // the conversation's original cwd (Claude keys history by cwd, so it must
+    // match or the session won't be found).
+    let extraArgs = null;
+    if (resumeId) {
+      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(resumeId)) {
+        return res.status(400).json({ error: 'Invalid resumeId' });
+      }
+      extraArgs = ['--resume', resumeId];
+      if (typeof resumeCwd === 'string' && resumeCwd) cwd = resumeCwd;
+    }
+
     // Create session
     const sessionId = uuidv4();
     const session = ptyManager.createSession(sessionId, {
@@ -62,7 +87,8 @@ router.post('/', (req, res) => {
       cols: cols || 80,
       rows: rows || 24,
       env: profileEnv,
-      profileId: profileId || null
+      profileId: profileId || null,
+      args: extraArgs
     });
 
     res.status(201).json({

--- a/server/index.js
+++ b/server/index.js
@@ -86,6 +86,14 @@ server.listen(PORT, '127.0.0.1', () => {
 └─────────────────────────────────────────┘
 `);
 
+  // Reattach to any tool sessions that survived a previous server restart
+  // (tmux durability layer in pty-manager). Best-effort; never blocks startup.
+  try {
+    require('./services/pty-manager').reviveSessions();
+  } catch (e) {
+    console.error('[index] reviveSessions failed:', e.message);
+  }
+
   // Auto-open browser if enabled
   if (process.env.AUTO_OPEN === '1') {
     setTimeout(() => openBrowser(`http://localhost:${PORT}`), 500);

--- a/server/services/conversations.js
+++ b/server/services/conversations.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Claude Code stores one JSONL per conversation under
+// ~/.claude/projects/<cwd-slug>/<sessionId>.jsonl . We surface these as
+// "past conversations" so the UI can resume one with `claude --resume <id>`.
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+
+// Pull the light metadata we need without holding the whole file: the cwd and
+// the first human message live near the top, so we can stop parsing early; the
+// message count / last activity need a full line scan (cheap even for MBs).
+function parseMeta(file) {
+  let cwd = null, title = null, first = null, last = null, count = 0;
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split('\n');
+  for (const line of lines) {
+    if (!line) continue;
+    let o;
+    try { o = JSON.parse(line); } catch { continue; }
+    if (!cwd && typeof o.cwd === 'string') cwd = o.cwd;
+    if (o.timestamp) { if (!first) first = o.timestamp; last = o.timestamp; }
+    if (o.type === 'user' || o.type === 'assistant') count++;
+    if (!title && o.type === 'user') {
+      let c = o.message && o.message.content;
+      if (Array.isArray(c)) {
+        c = c.filter(p => p && p.type === 'text').map(p => p.text).join(' ');
+      }
+      if (typeof c === 'string') {
+        const t = c.trim().replace(/\s+/g, ' ');
+        // Skip slash-commands, tool caveats and other non-prose openers.
+        if (t && !t.startsWith('<') && !t.startsWith('/')) title = t.slice(0, 120);
+      }
+    }
+  }
+  return { cwd, title, first, last, count };
+}
+
+// List past conversations, newest first. Skips stubs (< minMessages) and any
+// ids in `excludeIds` (e.g. sessions that are currently live).
+function listConversations({ limit = 60, minMessages = 2, excludeIds = [] } = {}) {
+  const exclude = new Set(excludeIds);
+  const out = [];
+  let keys;
+  try { keys = fs.readdirSync(PROJECTS_DIR); } catch { return out; }
+
+  for (const key of keys) {
+    const dir = path.join(PROJECTS_DIR, key);
+    let files;
+    try { files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl')); } catch { continue; }
+    for (const f of files) {
+      const id = f.slice(0, -6); // strip ".jsonl"
+      if (exclude.has(id)) continue;
+      const full = path.join(dir, f);
+      let stat, meta;
+      try { stat = fs.statSync(full); } catch { continue; }
+      try { meta = parseMeta(full); } catch { continue; }
+      if (meta.count < minMessages) continue; // drop empty/aborted stubs
+      // An untitled session with only a few events is a launch-and-exit stub
+      // (e.g. opened then /exit) — not worth resuming.
+      if (!meta.title && meta.count < 8) continue;
+      out.push({
+        id,
+        projectKey: key,
+        cwd: meta.cwd,
+        title: meta.title || '(untitled)',
+        messages: meta.count,
+        mtime: stat.mtimeMs,
+        lastActivity: meta.last,
+        sizeKb: Math.round(stat.size / 1024)
+      });
+    }
+  }
+  out.sort((a, b) => b.mtime - a.mtime);
+  return out.slice(0, limit);
+}
+
+module.exports = { listConversations };

--- a/server/services/pty-manager.js
+++ b/server/services/pty-manager.js
@@ -43,6 +43,58 @@ const sessions = new Map();
 // Default shell
 const defaultShell = process.env.SHELL || (os.platform() === 'win32' ? 'powershell.exe' : 'bash');
 
+// --- tmux durability layer -------------------------------------------------
+// Run coding tools inside a detached tmux session so they SURVIVE a nomacode
+// server restart instead of being SIGHUP-killed when the node process that
+// owns their PTY dies. The tmux server is a separate daemon (not a child of
+// node), so when we restart, the tool keeps running and can either be
+// reattached (reviveSessions) or exit cleanly on its own (writing its
+// /resume summary). Opt out with NOMACODE_NO_TMUX=1.
+const fs = require('fs');
+let TMUX_BIN = null;
+try {
+  if (spawnSync('tmux', ['-V'], { encoding: 'utf8' }).status === 0) TMUX_BIN = 'tmux';
+} catch (e) { /* no tmux available */ }
+
+const USE_TMUX = !!TMUX_BIN && ptyMethod === 'node-pty' && process.env.NOMACODE_NO_TMUX !== '1';
+const TMUX_CONF = path.join(os.homedir(), '.nomacode', 'tmux.conf');
+// Dedicated, short, deterministic socket so nomacode's tool sessions live on
+// their own tmux server — isolated from any interactive tmux the user runs.
+const TMUX_SOCK = 'nomacode';
+// Global tmux args that must precede every tmux subcommand.
+const TMUX_G = ['-L', TMUX_SOCK, '-f', TMUX_CONF];
+
+if (USE_TMUX) {
+  try {
+    fs.mkdirSync(path.dirname(TMUX_CONF), { recursive: true });
+    fs.writeFileSync(TMUX_CONF, [
+      'set -g status off',            // no tmux chrome — give the tool the full screen
+      'set -g prefix None',           // fully transparent: every key goes to the tool
+      'set -g mouse off',
+      'set -g history-limit 200000',
+      'set -g window-size latest',    // follow the most-recently-active client size
+      'setw -g aggressive-resize on',
+      'set -sg escape-time 0',        // no ESC delay (claude/ink read ESC directly)
+      'set -g destroy-unattached off',// keep the session alive while nomacode is gone
+      'set -g default-terminal "xterm-256color"',
+      'set -as terminal-features ",xterm-256color:RGB"',
+      ''
+    ].join('\n'));
+    console.log(`[pty-manager] tmux durability ON (${TMUX_BIN}) — tool sessions survive restarts`);
+  } catch (e) {
+    console.log('[pty-manager] tmux conf write failed, tmux disabled:', e.message);
+  }
+}
+
+function tmuxName(id) {
+  return 'nc_' + String(id).replace(/[^A-Za-z0-9_-]/g, '');
+}
+function tmuxSessionExists(name) {
+  if (!USE_TMUX) return false;
+  try { return spawnSync('tmux', [...TMUX_G, 'has-session', '-t', '=' + name]).status === 0; }
+  catch (e) { return false; }
+}
+
 function createSession(id, options = {}) {
   const {
     cwd = os.homedir(),
@@ -91,7 +143,27 @@ function createSession(id, options = {}) {
 
   if (ptyMethod === 'node-pty') {
     // Use node-pty for full PTY support
-    proc = ptyModule.spawn(command, args, {
+    let spawnCmd = command;
+    let spawnArgs = args;
+    let tmuxSessName = null;
+
+    if (USE_TMUX && tool) {
+      // Wrap the tool in a named tmux session. `-A` attaches to it if it
+      // already exists (e.g. it survived a previous server restart) and
+      // otherwise creates it running `inner`. Either way the tool lives in
+      // the tmux server, not as a direct child of node.
+      tmuxSessName = tmuxName(id);
+      const inner = [command, ...args].join(' ');
+      spawnCmd = 'tmux';
+      spawnArgs = [...TMUX_G, 'new-session', '-A',
+        '-s', tmuxSessName, '-c', cwd,
+        '-x', String(cols), '-y', String(rows), inner];
+      // A stray $TMUX in the env would make tmux refuse to nest.
+      delete processEnv.TMUX;
+      delete processEnv.TMUX_PANE;
+    }
+
+    proc = ptyModule.spawn(spawnCmd, spawnArgs, {
       name: 'xterm-256color',
       cols: cols,
       rows: rows,
@@ -111,13 +183,14 @@ function createSession(id, options = {}) {
       buffer: '',
       outputHandler: null,
       exitHandler: null,
-      ptyMethod: 'node-pty'
+      ptyMethod: 'node-pty',
+      tmuxName: tmuxSessName
     };
 
     proc.onData((data) => {
       session.buffer += data;
-      if (session.buffer.length > 50000) {
-        session.buffer = session.buffer.slice(-50000);
+      if (session.buffer.length > 500000) {
+        session.buffer = session.buffer.slice(-500000);
       }
       if (session.outputHandler) {
         session.outputHandler(data);
@@ -185,8 +258,8 @@ function setupChildProcessHandlers(session) {
   proc.stdout.on('data', (data) => {
     const str = data.toString();
     session.buffer += str;
-    if (session.buffer.length > 50000) {
-      session.buffer = session.buffer.slice(-50000);
+    if (session.buffer.length > 500000) {
+      session.buffer = session.buffer.slice(-500000);
     }
     if (session.outputHandler) {
       session.outputHandler(str);
@@ -197,8 +270,8 @@ function setupChildProcessHandlers(session) {
   proc.stderr.on('data', (data) => {
     const str = data.toString();
     session.buffer += str;
-    if (session.buffer.length > 50000) {
-      session.buffer = session.buffer.slice(-50000);
+    if (session.buffer.length > 500000) {
+      session.buffer = session.buffer.slice(-500000);
     }
     if (session.outputHandler) {
       session.outputHandler(str);
@@ -273,6 +346,11 @@ function resizeSession(id, cols, rows) {
 function killSession(id) {
   const session = sessions.get(id);
   if (session) {
+    // Explicit user-requested kill: actually terminate the tool. Tear down the
+    // tmux session first so the process inside it dies too, not just our client.
+    if (session.tmuxName && USE_TMUX) {
+      try { spawnSync('tmux', [...TMUX_G, 'kill-session', '-t', '=' + session.tmuxName]); } catch (e) {}
+    }
     if (session.pty && session.status === 'running') {
       if (session.ptyMethod === 'node-pty') {
         session.pty.kill();
@@ -287,9 +365,16 @@ function killSession(id) {
 }
 
 function killAllSessions() {
+  // Called on server shutdown/restart. For tmux-backed tool sessions we must
+  // NOT kill the tool — only drop our PTY client (a detach). The tmux server
+  // keeps the tool alive so it can be reattached on next start (reviveSessions)
+  // or exit cleanly on its own. This is the whole point of the tmux layer:
+  // restarting nomacode no longer SIGHUP-kills the running claude session.
   sessions.forEach((session) => {
     if (session.pty && session.status === 'running') {
-      if (session.ptyMethod === 'node-pty') {
+      if (session.tmuxName && USE_TMUX) {
+        try { session.pty.kill(); } catch (e) {} // detach only, tmux session lives on
+      } else if (session.ptyMethod === 'node-pty') {
         session.pty.kill();
       } else {
         session.pty.kill('SIGTERM');
@@ -297,6 +382,46 @@ function killAllSessions() {
     }
   });
   sessions.clear();
+}
+
+// Reattach to tmux tool-sessions that outlived a previous server process.
+// Call this once at startup so surviving sessions reappear in the UI and the
+// browser can reconnect to them by id.
+function reviveSessions() {
+  if (!USE_TMUX) return [];
+  let out;
+  try {
+    const r = spawnSync('tmux',
+      [...TMUX_G, 'list-sessions', '-F', '#{session_name}\t#{pane_current_path}'],
+      { encoding: 'utf8' });
+    if (r.status !== 0 || !r.stdout) return [];
+    out = r.stdout;
+  } catch (e) { return []; }
+
+  const revived = [];
+  out.split('\n').map((s) => s.trim()).filter(Boolean).forEach((line) => {
+    const [name, panePath] = line.split('\t');
+    if (!name || !name.startsWith('nc_')) return;
+    const id = name.slice(3);
+    if (sessions.has(id)) return;
+    try {
+      // createSession() with a matching id re-runs `tmux new-session -A`, which
+      // reattaches to the existing session without starting a second tool.
+      createSession(id, {
+        tool: 'claude-code',
+        cwd: panePath || os.homedir(),
+        cols: 80,
+        rows: 24
+      });
+      revived.push(id);
+    } catch (e) {
+      console.error('[pty-manager] revive failed for', name, '-', e.message);
+    }
+  });
+  if (revived.length) {
+    console.log(`[pty-manager] revived ${revived.length} tmux session(s): ${revived.join(', ')}`);
+  }
+  return revived;
 }
 
 function getPtyMethod() {
@@ -311,5 +436,6 @@ module.exports = {
   resizeSession,
   killSession,
   killAllSessions,
+  reviveSessions,
   getPtyMethod
 };

--- a/server/services/pty-manager.js
+++ b/server/services/pty-manager.js
@@ -155,9 +155,18 @@ function createSession(id, options = {}) {
       tmuxSessName = tmuxName(id);
       const inner = [command, ...args].join(' ');
       spawnCmd = 'tmux';
+      // Pass per-session env explicitly with -e. The tmux SERVER is shared
+      // across sessions and inherits its environment from whichever client
+      // first started it, so profile credentials placed only in this client's
+      // env would be ignored for every session after the first — a second
+      // profile would silently run with the first profile's API key.
+      const envArgs = [];
+      for (const [k, v] of Object.entries(env || {})) {
+        if (v !== undefined && v !== null) envArgs.push('-e', `${k}=${v}`);
+      }
       spawnArgs = [...TMUX_G, 'new-session', '-A',
         '-s', tmuxSessName, '-c', cwd,
-        '-x', String(cols), '-y', String(rows), inner];
+        '-x', String(cols), '-y', String(rows), ...envArgs, inner];
       // A stray $TMUX in the env would make tmux refuse to nest.
       delete processEnv.TMUX;
       delete processEnv.TMUX_PANE;

--- a/server/services/pty-manager.js
+++ b/server/services/pty-manager.js
@@ -102,7 +102,8 @@ function createSession(id, options = {}) {
     cols = 80,
     rows = 24,
     env = {},
-    profileId = null
+    profileId = null,
+    args: extraArgs = null // e.g. ['--resume', '<id>'] to resume a conversation
   } = options;
 
   // Determine command to run
@@ -113,20 +114,17 @@ function createSession(id, options = {}) {
     switch (tool) {
       case 'claude-code':
         command = 'claude';
-        args = [];
         break;
       case 'opencode':
         command = 'opencode';
-        args = [];
         break;
       case 'codex':
         command = 'codex';
-        args = [];
         break;
       default:
         command = defaultShell;
-        args = [];
     }
+    if (Array.isArray(extraArgs)) args = extraArgs;
   }
 
   const processEnv = {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -419,6 +419,9 @@ body.keyboard-visible #main-content {
   flex-shrink: 0;
 }
 .recent-item .repo-name {
+  /* min-width:0 lets a flex child shrink below its content width so a long
+     conversation title ellipsizes instead of overflowing the viewport. */
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -294,12 +294,16 @@ body.keyboard-visible #main-content {
   align-items: center;
   justify-content: center;
   background: var(--bg);
+  /* Never let a wide child (long titles, ascii logo) scroll the page sideways. */
+  overflow-x: hidden;
 }
 
 .welcome-content {
   text-align: center;
+  width: 100%;
   max-width: 600px;
   padding: 20px;
+  box-sizing: border-box;
 }
 
 .ascii-logo {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -412,6 +412,18 @@ body.keyboard-visible #main-content {
   font-size: 11px;
 }
 
+/* Message-count badge on a "Resume Conversation" item */
+.recent-item .convo-meta {
+  color: var(--text-dim);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+.recent-item .repo-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Key Toolbar (mobile) - only visible with keyboard, sticks above keyboard */
 #key-toolbar {
   position: absolute;

--- a/web/index.html
+++ b/web/index.html
@@ -73,6 +73,11 @@
             </div>
           </div>
 
+          <div id="recent-convos" class="recent-section hidden">
+            <p class="section-title">─── Resume Conversation ───</p>
+            <div id="convo-list"></div>
+          </div>
+
           <div id="recent-repos" class="recent-section hidden">
             <p class="section-title">─── Recent Repositories ───</p>
             <div id="recent-list"></div>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -75,6 +75,16 @@ const API = {
       return API.request('POST', '/sessions', body);
     },
 
+    // Past Claude conversations that can be resumed.
+    conversations() {
+      return API.request('GET', '/sessions/conversations');
+    },
+
+    // Start a new session that resumes a past conversation (`claude --resume`).
+    resume(resumeId, cwd) {
+      return API.request('POST', '/sessions', { tool: 'claude-code', resumeId, cwd });
+    },
+
     delete(id) {
       return API.request('DELETE', `/sessions/${id}`);
     },

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -893,6 +893,49 @@ class Nomacode {
     this.updateClaudeModeDisplay();
     this.renderTabs();
     this.updateStatusBar();
+    this.updateRecentConversations();
+  }
+
+  // Populate the "Resume Conversation" list from past Claude sessions on disk.
+  async updateRecentConversations() {
+    const section = document.getElementById('recent-convos');
+    const list = document.getElementById('convo-list');
+    if (!section || !list) return;
+
+    let convos = [];
+    try { convos = await API.sessions.conversations(); } catch (e) { /* offline: hide */ }
+
+    if (!convos.length) {
+      section.classList.add('hidden');
+      return;
+    }
+    section.classList.remove('hidden');
+
+    list.innerHTML = convos.slice(0, 8).map(c => `
+      <button class="recent-item" data-id="${c.id}" data-cwd="${this.escapeHtml(c.cwd || '')}">
+        <span class="repo-icon">💬</span>
+        <span class="repo-name">${this.escapeHtml(c.title)}</span>
+        <span class="convo-meta">${c.messages}</span>
+      </button>
+    `).join('');
+
+    list.querySelectorAll('.recent-item').forEach(item => {
+      item.addEventListener('click', () =>
+        this.resumeConversation(item.dataset.id, item.dataset.cwd));
+    });
+  }
+
+  // Resume a past conversation in a fresh session (`claude --resume <id>`).
+  async resumeConversation(id, cwd) {
+    try {
+      const session = await API.sessions.resume(id, cwd);
+      this.sessions.push(session);
+      this.switchToSession(session.id);
+      this.toast('Resuming conversation…', 'success');
+    } catch (e) {
+      console.error('Resume error:', e);
+      this.toast(e.message, 'error');
+    }
   }
 
   // ─── Command Palette ─────────────────────────────────────

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for Nomacode PWA
 // Bump on every shipped asset change so clients don't serve stale JS/CSS.
-const CACHE_NAME = 'nomacode-v3';
+const CACHE_NAME = 'nomacode-v4';
 
 // Assets to cache for offline use
 const STATIC_ASSETS = [

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,6 @@
 // Service Worker for Nomacode PWA
-const CACHE_NAME = 'nomacode-v1';
+// Bump on every shipped asset change so clients don't serve stale JS/CSS.
+const CACHE_NAME = 'nomacode-v2';
 
 // Assets to cache for offline use
 const STATIC_ASSETS = [

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for Nomacode PWA
 // Bump on every shipped asset change so clients don't serve stale JS/CSS.
-const CACHE_NAME = 'nomacode-v2';
+const CACHE_NAME = 'nomacode-v3';
 
 // Assets to cache for offline use
 const STATIC_ASSETS = [


### PR DESCRIPTION
Ports two features from `shaman4ik/nomacode-RE` (items 1 and 2 of the fork review), rebased onto current `main` and adapted where the fork's code predates work we've since merged.

Credit for the original implementation goes to @shaman4ik.

## 1. tmux-backed durable sessions (`a2ac499`)

Each tool runs inside a named `tmux -L nomacode` session, so it lives in the tmux daemon rather than as a direct child of node. Restarting the server no longer SIGHUP-kills a running Claude session:

- `killAllSessions()` (shutdown) only **detaches** — the tool keeps running
- `reviveSessions()` reattaches every `nc_*` session at startup
- `killSession()` (explicit user action) still tears the tmux session down
- Opt out with `NOMACODE_NO_TMUX=1`; falls back cleanly when tmux is absent

## 2. Resumable past conversations (`db98185` + 2 overflow fixes)

`conversations.js` parses Claude Code's `~/.claude/projects/*.jsonl` to list prior conversations on the welcome screen; picking one launches `claude --resume <id>` from its original cwd.

## Added fix: per-session env under tmux

**This is a genuine bug introduced by combining the two features**, not present in either upstream — the tmux layer and our API profiles feature were developed independently and first meet here.

The tmux **server** is shared across sessions and inherits its environment from whichever client first started it. Profile credentials were placed only in the spawning client's env, so every session after the first silently ran with the **first session's API key**.

Reproduced against tmux 3.7b:

```
first create  (env MYKEY=AAA) -> KEY=AAA
second create (env MYKEY=BBB) -> KEY=AAA   # wrong
```

Concretely: start a session on the MiniMax profile, then one on GLM, and the GLM session runs with MiniMax's key. Silent wrong-credential use, no error.

Fixed by passing each variable explicitly with `-e`, which applies per session even on an existing server.

## Verification

Ran against real tmux 3.7b:

```
PASS session1 gets profile A key   (ANTHROPIC_API_KEY=sk-KEYAAA)
PASS session2 gets profile B key   (ANTHROPIC_API_KEY=sk-KEYBBB)
PASS keys are NOT shared

PASS session created in tmux
PASS survives killAllSessions (detach only)
PASS reviveSessions found it
PASS killSession destroys tmux session

PASS conversation title/cwd/id parsed from JSONL
PASS rejects "…; touch /tmp/pwned"   (resumeId injection)
PASS rejects "$(touch /tmp/pwned2)"
PASS rejects "`id`"
PASS rejects "../../etc/passwd"
PASS accepts valid uuid
```

`resumeId` is shell-joined into the tmux command string, so its UUID validation is load-bearing; the injection cases above confirm it holds.

Also confirmed no regressions against everything merged this session: PR #6 mode detection, #7 tool-detector, #8 pty probe, #9 Enter key, API profiles, `escapeAttr`.

## Conflicts resolved

- `pty-manager.js` / `sessions.js` — kept both our `profileId` and the fork's `args`/`resumeId`
- `web/sw.js` — the fork's cache counter (`v33`–`v35`) is meaningless here; used our own sequence, ending at `nomacode-v4`

## Not covered

Not tested on Termux. tmux must be installed there (`pkg install tmux`) for the durability layer to engage; without it the code falls back to the current behaviour, so this is a no-op rather than a break.

`reviveSessions()` hardcodes `tool: 'claude-code'`, so a revived OpenCode session would be mislabelled in the UI. Pre-existing in the original commit; left as-is to keep this port faithful, worth a follow-up.