### PR TITLE
Detect Claude's current manual/auto permission mode names

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -14,6 +14,7 @@
   --yellow: #d29922;
   --red: #f85149;
   --purple: #a371f7;
+  --cyan: #39c5cf;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
   --topbar-height: 56px;
   --toolbar-height: 44px;
@@ -580,6 +581,12 @@ body.keyboard-visible #statusbar {
 
 #status-mode.accept {
   background: var(--purple);
+}
+
+/* Claude's "auto" permission mode — distinct from acceptEdits, so it gets its
+   own colour rather than reusing the ACCEPT purple. */
+#status-mode.auto {
+  background: var(--cyan);
 }
 
 #status-cwd {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -737,17 +737,27 @@ class Nomacode {
     // every unrelated redraw, so ACCEPT/PLAN flickered straight back to NORMAL.
     let newMode = undefined;
 
+    // Claude Code's permission modes are: manual, auto, acceptEdits, plan
+    // (plus bypassPermissions / dontAsk). Shift+Tab cycles the first few and
+    // announces the new one as "<mode> mode on". "manual" is the baseline that
+    // we surface as NORMAL.
+    //
     // Check the exit markers FIRST: "plan mode off" and "exited plan mode"
     // both contain "plan mode", so an entry-first ordering claims them and the
     // label sticks on PLAN forever. No loose /plan.*mode/ regex either — it
     // matches ordinary prose like "I'll plan the refactor in normal mode",
     // and Claude's own output is echoed to the terminal.
-    if (clean.includes('exited plan') || clean.includes('plan mode off') || clean.includes('accept edits off')) {
+    if (clean.includes('exited plan') || clean.includes('plan mode off') ||
+        clean.includes('accept edits off') || clean.includes('manual mode on')) {
       newMode = null;
     } else if (clean.includes('plan mode on') || clean.includes('[plan]')) {
       newMode = 'PLAN';
-    } else if (clean.includes('accept edits on') || clean.includes('autoaccept') || clean.includes('auto-accept') || clean.includes('[auto]')) {
+    } else if (clean.includes('accept edits on') || clean.includes('autoaccept') ||
+               clean.includes('auto-accept') || clean.includes('[auto]')) {
       newMode = 'ACCEPT';
+    } else if (clean.includes('auto mode on')) {
+      // Distinct from acceptEdits: auto mode picks permissions per tool call.
+      newMode = 'AUTO';
     }
 
     if (newMode !== undefined && newMode !== this.claudeMode) {


### PR DESCRIPTION
## Problem

The status bar showed a stale mode label. In the reported screenshot the terminal reads `⏸ manual mode on` while the chip still says something else — the label had simply never been updated.

`detectClaudeMode()` had no branch matching `manual mode on`, so `newMode` stayed `undefined` ("this chunk carries no mode info, leave the label alone") and whatever was there before persisted.

## Root cause

The detector was written against older wording. The authoritative list, from `claude --permission-mode`:

```
Allowed choices are acceptEdits, auto, bypassPermissions, manual, dontAsk, plan.
```

Two gaps:

1. **`manual`** is the baseline mode — what we display as NORMAL — but the string `manual mode on` matched nothing, so cycling back to manual never cleared the label.
2. **`auto`** is a real mode we never handled at all. It is *not* `acceptEdits` (auto decides permissions per tool call), so folding it into ACCEPT would have been wrong.

## Changes

- `manual mode on` → clears the label to NORMAL
- `auto mode on` → new `AUTO` state with its own label
- Add the `--cyan` token (`#39c5cf`, matching the existing xterm theme colour) and a `#status-mode.auto` rule

The CSS token matters: `updateClaudeModeDisplay()` derives the class from the mode name (`AUTO` → `.auto`), so introducing the state without the rule would have rendered the chip with no background.

Legacy strings (`autoaccept`, `auto-accept`, `[auto]`, `[plan]`) are kept, and the exit-before-entry ordering from #6 is preserved.

## Verification

Drove the real `detectClaudeMode` extracted from `app.js`:

```
PASS "⏸ manual mode on"     -> null (NORMAL)
PASS "⏵⏵ auto mode on"      -> AUTO
PASS "⏸ plan mode on"       -> PLAN
PASS "⏵⏵ accept edits on"   -> ACCEPT
PASS "accept edits off"     -> null
PASS "exited plan mode"     -> null
PASS "npm build finished"   -> undefined (label untouched)
PASS screenshot case: ACCEPT + "manual mode on" -> NORMAL
PASS AUTO -> css class .auto
```

The unrelated-output case confirms #6's no-flicker behaviour still holds.

## Note

`bypassPermissions` and `dontAsk` are still unhandled — they aren't in the Shift+Tab cycle, so they don't produce a "<mode> mode on" line in normal use. Worth adding if that changes.