### PR TITLE
Mobile key strip: reachable ESC, pinned mode chip, reclaimed vertical space

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -440,7 +440,12 @@ body.keyboard-visible #main-content {
   right: 0;
   display: none;
   align-items: center;
-  justify-content: center;
+  /* NOT `center`: this strip scrolls horizontally once the keys stop fitting,
+     and centring a scrollable flex row makes the overflow spill off BOTH
+     edges — the leading keys (ESC first) become unreachable because the
+     scrollable area starts past them. Pack from the start instead, so the
+     strip always begins at ESC and only overflows to the right. */
+  justify-content: flex-start;
   gap: 4px;
   height: var(--toolbar-height);
   padding: 0 8px;
@@ -555,6 +560,19 @@ body.keyboard-visible #statusbar {
   gap: 8px;
 }
 
+/* cwd / tool / session counter duplicate the tab bar. On a phone that row is
+   pure overhead, so keep only the mode chip and let the bar shrink. */
+@media (max-width: 600px) {
+  .status-detail {
+    display: none;
+  }
+
+  #statusbar {
+    justify-content: flex-start;
+    padding: 0 8px;
+  }
+}
+
 #status-mode {
   color: var(--bg);
   background: var(--green);
@@ -587,6 +605,13 @@ body.keyboard-visible #statusbar {
    own colour rather than reusing the ACCEPT purple. */
 #status-mode.auto {
   background: var(--cyan);
+}
+
+/* bypassPermissions skips every permission prompt. Red, and bright text, so
+   it reads as a warning rather than just another mode. */
+#status-mode.bypass {
+  background: var(--red);
+  color: var(--text-bright);
 }
 
 #status-cwd {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -222,7 +222,10 @@ html, body {
   overflow: hidden;
 }
 
-/* When keyboard is visible, make room for toolbar */
+/* Reserve room whenever the key strip is on screen. It is no longer tied to
+   the keyboard being open, so keying off .keyboard-visible alone would let
+   the strip overlap the terminal's last line with the keyboard closed. */
+body:has(#key-toolbar.visible) #main-content,
 body.keyboard-visible #main-content {
   bottom: calc(var(--toolbar-height) + var(--statusbar-height));
 }
@@ -526,8 +529,16 @@ body.keyboard-visible #main-content {
     display: none !important;
   }
 
+  /* The strip is hidden here, so reclaim its reserved space — including from
+     the :has() rules above, which would otherwise leave a phantom gap. */
+  body:has(#key-toolbar.visible) #main-content,
   body.keyboard-visible #main-content {
     bottom: var(--statusbar-height);
+  }
+
+  body:has(#key-toolbar.visible) #statusbar,
+  body.keyboard-visible #statusbar {
+    bottom: 0;
   }
 }
 
@@ -549,7 +560,9 @@ body.keyboard-visible #main-content {
   z-index: 100;
 }
 
-/* When keyboard visible, statusbar goes above toolbar */
+/* The statusbar sits directly above the key strip whenever that strip is
+   shown — again not just when the keyboard is open. */
+body:has(#key-toolbar.visible) #statusbar,
 body.keyboard-visible #statusbar {
   bottom: var(--toolbar-height);
 }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -222,11 +222,11 @@ html, body {
   overflow: hidden;
 }
 
-/* Reserve room whenever the key strip is on screen. It is no longer tied to
-   the keyboard being open, so keying off .keyboard-visible alone would let
-   the strip overlap the terminal's last line with the keyboard closed. */
-body:has(#key-toolbar.visible) #main-content,
-body.keyboard-visible #main-content {
+/* Reserve room whenever the key strip is on screen. Keyed off the strip's own
+   .visible class, not .keyboard-visible: the strip is no longer tied to the
+   keyboard being open, so it would otherwise overlap the terminal's last line
+   whenever the keyboard was closed. */
+body:has(#key-toolbar.visible) #main-content {
   bottom: calc(var(--toolbar-height) + var(--statusbar-height));
 }
 
@@ -443,11 +443,6 @@ body.keyboard-visible #main-content {
   right: 0;
   display: none;
   align-items: center;
-  /* NOT `center`: this strip scrolls horizontally once the keys stop fitting,
-     and centring a scrollable flex row makes the overflow spill off BOTH
-     edges — the leading keys (ESC first) become unreachable because the
-     scrollable area starts past them. Pack from the start instead, so the
-     strip always begins at ESC and only overflows to the right. */
   justify-content: flex-start;
   gap: 4px;
   height: var(--toolbar-height);
@@ -455,8 +450,39 @@ body.keyboard-visible #main-content {
   background: var(--bg-light);
   border-top: 1px solid var(--border);
   z-index: 101;
+  /* The strip itself does NOT scroll — only #key-scroll does. That keeps the
+     mode chip and Enter pinned at the edges where they can't scroll away. */
+  overflow: hidden;
+}
+
+/* The scrolling middle. Packed from flex-start, never centred: centring a
+   scrollable flex row pushes the overflow off BOTH edges, so the leading keys
+   (ESC first) sit before the scrollable area and can't be reached. */
+#key-scroll {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+#key-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+/* Mode chip, pinned left. Colours come from the #status-mode rules below. */
+#key-toolbar > #status-mode {
+  flex-shrink: 0;
+  min-width: 62px;
+  padding: 0 8px;
+  height: 36px;
+  border: none;
+  font-size: 10px;
+  letter-spacing: 0.3px;
 }
 
 #key-toolbar.visible {
@@ -507,12 +533,14 @@ body.keyboard-visible #main-content {
 }
 
 /* Enter is the most-used key on a soft keyboard that swallows its own
-   Return, so give it a wider target and accent it as the primary action. */
+   Return, so give it a wider target and accent it as the primary action.
+   Pinned outside #key-scroll so it never scrolls out of reach. */
 .key-btn-enter {
   min-width: 60px;
   border-color: var(--accent);
   color: var(--accent);
   font-size: 15px;
+  flex-shrink: 0;
 }
 
 .toolbar-sep {
@@ -523,21 +551,21 @@ body.keyboard-visible #main-content {
   flex-shrink: 0;
 }
 
-/* Never show toolbar on desktop (even with keyboard) */
-@media (min-width: 768px) and (hover: hover) {
+/* Never show the strip on a wide screen — there's a real keyboard there.
+   Width alone, no `(hover: hover)`: a touch-capable laptop failed that test,
+   so the strip hid while the :has() rules above still reserved its space,
+   leaving the statusbar overlapping the terminal's last line. Hiding and
+   space-reclaiming must be driven by the SAME condition. */
+@media (min-width: 768px) {
   #key-toolbar {
     display: none !important;
   }
 
-  /* The strip is hidden here, so reclaim its reserved space — including from
-     the :has() rules above, which would otherwise leave a phantom gap. */
-  body:has(#key-toolbar.visible) #main-content,
-  body.keyboard-visible #main-content {
+  body:has(#key-toolbar.visible) #main-content {
     bottom: var(--statusbar-height);
   }
 
-  body:has(#key-toolbar.visible) #statusbar,
-  body.keyboard-visible #statusbar {
+  body:has(#key-toolbar.visible) #statusbar {
     bottom: 0;
   }
 }
@@ -562,8 +590,7 @@ body.keyboard-visible #main-content {
 
 /* The statusbar sits directly above the key strip whenever that strip is
    shown — again not just when the keyboard is open. */
-body:has(#key-toolbar.visible) #statusbar,
-body.keyboard-visible #statusbar {
+body:has(#key-toolbar.visible) #statusbar {
   bottom: var(--toolbar-height);
 }
 
@@ -573,16 +600,16 @@ body.keyboard-visible #statusbar {
   gap: 8px;
 }
 
-/* cwd / tool / session counter duplicate the tab bar. On a phone that row is
-   pure overhead, so keep only the mode chip and let the bar shrink. */
+/* cwd / tool / session counter all duplicate the tab bar, and the mode chip
+   now lives in the key strip — so on a phone this row has nothing unique left
+   to show. Drop it entirely and give its 32px back to the terminal. */
 @media (max-width: 600px) {
-  .status-detail {
+  #statusbar {
     display: none;
   }
 
-  #statusbar {
-    justify-content: flex-start;
-    padding: 0 8px;
+  #main-content {
+    bottom: 0;
   }
 }
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1274,23 +1274,17 @@ body:has(#key-toolbar.visible) #statusbar {
   }
 }
 
-/* Scrollbar */
+/* Scrollbars are chrome in a terminal-style UI: content still scrolls, the
+   bar just isn't drawn. The tab strip, key strip and terminal already hid
+   theirs individually; this makes it the default everywhere instead. */
+* {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--bg);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 4px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--text-dim);
+  width: 0;
+  height: 0;
 }
 
 /* Selection */

--- a/web/index.html
+++ b/web/index.html
@@ -103,13 +103,16 @@
     </div>
 
     <!-- Status Bar -->
+    <!-- Mode is the only genuinely dynamic thing here. The cwd, tool name and
+         session counter all restate what the tab bar already shows, so they
+         are dropped on narrow screens to give the key strip its space back. -->
     <footer id="statusbar">
       <div class="status-left">
         <span id="status-mode">NORMAL</span>
-        <span class="separator">│</span>
-        <span id="status-cwd">~</span>
+        <span class="separator status-detail">│</span>
+        <span id="status-cwd" class="status-detail">~</span>
       </div>
-      <div class="status-right">
+      <div class="status-right status-detail">
         <span id="status-tool"></span>
         <span class="separator">│</span>
         <span id="status-session"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -86,33 +86,36 @@
       </div>
     </main>
 
-    <!-- Key Toolbar (mobile) -->
+    <!-- Key Toolbar (mobile). The mode chip is pinned outside the scrolling
+         strip so it can't scroll away, and so it no longer needs a status-bar
+         row of its own. Enter is pinned on the right for the same reason: it's
+         the most-used key and must never require a scroll to reach. -->
     <div id="key-toolbar">
-      <button class="key-btn" data-key="Escape">ESC</button>
-      <button class="key-btn modifier" data-modifier="ctrl">CTRL</button>
-      <button class="key-btn modifier" data-modifier="alt">ALT</button>
-      <button class="key-btn" data-key="Tab">TAB</button>
-      <span class="toolbar-sep"></span>
-      <button class="key-btn" data-key="ArrowUp">↑</button>
-      <button class="key-btn" data-key="ArrowDown">↓</button>
-      <button class="key-btn" data-key="ArrowLeft">←</button>
-      <button class="key-btn" data-key="ArrowRight">→</button>
-      <span class="toolbar-sep"></span>
-      <button class="key-btn" data-key="Backspace" aria-label="Backspace">⌫</button>
+      <button id="status-mode" class="key-btn" title="Cycle Claude permission mode">NORMAL</button>
+      <div id="key-scroll">
+        <button class="key-btn" data-key="Escape">ESC</button>
+        <button class="key-btn modifier" data-modifier="ctrl">CTRL</button>
+        <button class="key-btn modifier" data-modifier="alt">ALT</button>
+        <button class="key-btn" data-key="Tab">TAB</button>
+        <span class="toolbar-sep"></span>
+        <button class="key-btn" data-key="ArrowUp">↑</button>
+        <button class="key-btn" data-key="ArrowDown">↓</button>
+        <button class="key-btn" data-key="ArrowLeft">←</button>
+        <button class="key-btn" data-key="ArrowRight">→</button>
+        <span class="toolbar-sep"></span>
+        <button class="key-btn" data-key="Backspace" aria-label="Backspace">⌫</button>
+      </div>
       <button class="key-btn key-btn-enter" data-key="Enter" aria-label="Enter">⏎</button>
     </div>
 
-    <!-- Status Bar -->
-    <!-- Mode is the only genuinely dynamic thing here. The cwd, tool name and
-         session counter all restate what the tab bar already shows, so they
-         are dropped on narrow screens to give the key strip its space back. -->
+    <!-- Status Bar. The mode chip moved into the key strip, and cwd / tool /
+         session counter all restate what the tab bar already shows, so the
+         whole row is hidden on narrow screens — 32px back to the terminal. -->
     <footer id="statusbar">
       <div class="status-left">
-        <span id="status-mode">NORMAL</span>
-        <span class="separator status-detail">│</span>
-        <span id="status-cwd" class="status-detail">~</span>
+        <span id="status-cwd">~</span>
       </div>
-      <div class="status-right status-detail">
+      <div class="status-right">
         <span id="status-tool"></span>
         <span class="separator">│</span>
         <span id="status-session"></span>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -755,6 +755,12 @@ class Nomacode {
     } else if (clean.includes('accept edits on') || clean.includes('autoaccept') ||
                clean.includes('auto-accept') || clean.includes('[auto]')) {
       newMode = 'ACCEPT';
+    } else if (clean.includes('bypass permissions on') || clean.includes('bypassing permissions') ||
+               clean.includes('bypass permissions mode on')) {
+      // Every permission prompt is skipped in this mode, so surface it loudly
+      // (red chip) rather than as just another state — the user should never
+      // be in it without knowing.
+      newMode = 'BYPASS';
     } else if (clean.includes('auto mode on')) {
       // Distinct from acceptEdits: auto mode picks permissions per tool call.
       newMode = 'AUTO';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -84,15 +84,20 @@ class Nomacode {
       const heightDiff = initialHeight - vh;
       const keyboardVisible = heightDiff > keyboardThreshold;
 
-      // Toggle keyboard visibility class and toolbar
-      const toolbar = document.getElementById('key-toolbar');
+      // The keyboard-visible class only drives layout offsets (the toolbar
+      // sits above the keyboard when it's up).
       if (keyboardVisible) {
         document.body.classList.add('keyboard-visible');
-        toolbar?.classList.add('visible');
       } else {
         document.body.classList.remove('keyboard-visible');
-        toolbar?.classList.remove('visible');
       }
+
+      // Toolbar visibility is deliberately NOT tied to the keyboard: ESC,
+      // the arrows and Ctrl are exactly the keys you need while the keyboard
+      // is closed (navigating Claude's menus, sending Ctrl+C, dismissing a
+      // prompt). Gating them on an open keyboard made them unreachable at
+      // the moment they were most useful.
+      this.updateKeyToolbar();
 
       // Refit terminal when viewport changes
       if (this.activeSessionId) {
@@ -900,11 +905,16 @@ class Nomacode {
       terminalView.classList.add('hidden');
       terminalView.classList.remove('active');
     }
+
+    // The strip belongs to the terminal, not the welcome screen.
+    this.updateKeyToolbar();
   }
 
   showWelcome() {
-    this.showView('welcome');
+    // Clear the active session BEFORE showView: updateKeyToolbar() reads it,
+    // and a stale id would leave the key strip on the welcome screen.
     this.activeSessionId = null;
+    this.showView('welcome');
     this.claudeMode = null;
     this.updateClaudeModeDisplay();
     this.renderTabs();
@@ -1931,6 +1941,19 @@ class Nomacode {
   }
 
   // ─── Key Toolbar ────────────────────────────────────────────
+
+  // Show the key strip whenever a terminal is on screen on a touch device.
+  // Desktop keeps it hidden (there's a real keyboard, and the media query in
+  // style.css hides it there anyway).
+  updateKeyToolbar() {
+    const toolbar = document.getElementById('key-toolbar');
+    if (!toolbar) return;
+
+    const terminalVisible = !!this.activeSessionId &&
+      !document.getElementById('terminal-view')?.classList.contains('hidden');
+
+    toolbar.classList.toggle('visible', terminalVisible);
+  }
 
   bindKeyToolbar() {
     const toolbar = document.getElementById('key-toolbar');


### PR DESCRIPTION
Four related fixes to the mobile key strip and status bar, from device screenshots.

## 1. ESC was unreachable

`#key-toolbar` was `overflow-x: auto` with `justify-content: center`. **Centring a scrollable flex row pushes the overflow off both edges**, so the leading keys sat before the scrollable area and could not be scrolled to. Screenshots showed the strip starting at `RL` (tail of CTRL), then at `TAB`, then at `ALT` — ESC always gone.

The keys are `flex-shrink: 0` at `min-width: 44px`, so twelve of them need ~598px against a ~390px viewport: it always overflows.

**Fix:** the toolbar itself no longer scrolls. A new `#key-scroll` middle region scrolls instead, packed from `flex-start`, with the mode chip pinned left and Enter pinned right. ESC is the first item in the scrolling region and Enter can never scroll out of reach.

## 2. Key strip vanished with the keyboard closed

The strip was only shown while the on-screen keyboard was open (viewport shrunk >150px). That is backwards: ESC, the arrows and Ctrl are exactly what you need *without* the keyboard up — navigating Claude's menus, sending Ctrl+C, dismissing a prompt. With no physical keyboard there was then no way to send those keys at all.

**Fix:** visibility follows the terminal view — shown whenever a session is on screen, hidden on the welcome screen. `.keyboard-visible` still drives layout offsets for when the keyboard is up.

`showWelcome()` now clears `activeSessionId` *before* `showView()`, since `updateKeyToolbar()` reads it and a stale id left the strip on the welcome screen.

## 3. Statusbar overlapped the terminal on desktop

The hide-on-desktop query was `(min-width: 768px) and (hover: hover)`. A touch-capable laptop **fails the hover test**, so the strip stayed hidden by width while the `:has(#key-toolbar.visible)` rules still reserved its 44px — leaving the statusbar sitting on top of the terminal's last line.

**Fix:** hiding and space-reclaiming now key off the same condition (width alone). Splitting those two across different conditions is what created the gap.

## 4. Reclaimed the statusbar row on mobile

The mode chip moved into the key strip, and cwd / tool name / session counter all restate the tab bar (the tab label is literally `repoName || tool`). With nothing unique left, the whole row is hidden under 600px — 32px back to the terminal. Still shown on desktop.

## Also: BYPASS mode

Follow-up to #11, which noted `bypassPermissions` was unhandled. It skips **every** permission prompt, so it gets a red chip with bright text rather than blending in — being in it unknowingly is the failure mode worth guarding against.

`dontAsk` remains unhandled: it isn't in the Shift+Tab cycle and I have no confirmed output string. Guessing at wording risks the false-positive class of bug #6 fixed.

## Verification

```
PASS "⏸ manual mode on"         -> null (NORMAL)
PASS "⏵⏵ auto mode on"          -> AUTO
PASS "⏸ plan mode on"           -> PLAN
PASS "⏵⏵ accept edits on"       -> ACCEPT
PASS "bypass permissions on"    -> BYPASS
PASS "accept edits off"         -> null
PASS unrelated output preserves label   (#6 no-flicker still holds)

PASS session active + terminal shown -> toolbar VISIBLE
PASS no session -> toolbar hidden
PASS terminal hidden -> toolbar hidden

PASS mode chip inside toolbar, removed from statusbar
PASS ESC inside scroll region, Enter outside it
```

## Not verified

The CSS is reasoned from the box model and measured widths plus structural checks — not rendered on a device. Worth confirming on your phone that ESC is reachable, the mode chip stays pinned, and the terminal isn't clipped; and on the touch laptop that the overlap is gone.