### PR TITLE
Install OpenCode natively on Termux; remove Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **OpenCode runs natively on Termux** — installs from the prebuilt aarch64 packages published by [guysoft/opencode-termux](https://github.com/guysoft/opencode-termux), which cross-compiles Bun and WebKit/JSC for Android. The install is verified against the release's published SHA256SUMS.
+
+### Removed
+- **Codex support** — removed from the tool list, session launcher, settings validation and UI. The "coming soon" badge mechanism it was the sole user of is gone too.
+
+### Platform Notes
+- The previous note that OpenCode "does not work natively on Termux/Android" no longer applies. `npm install -g opencode-ai` still cannot work there — OpenCode compiles via Bun, which has no Android support — so on Termux Nomacode installs the prebuilt aarch64 build instead.
+
 ## v2026.3.1 (2026-03-03)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Nomacode is a mobile-first PWA for running AI coding assistants (Claude Code, OpenCode, Codex) on Android via Termux. It provides a terminal emulator interface with repository management and multi-session support.
+Nomacode is a mobile-first PWA for running AI coding assistants (Claude Code, OpenCode) on Android via Termux. It provides a terminal emulator interface with repository management and multi-session support.
 
 **Stack**: Express backend + Vanilla JS frontend with xterm.js
 

--- a/README.md
+++ b/README.md
@@ -71,19 +71,17 @@ Currently Nomacode requires Termux, which is Android-only. iOS implementation id
 
 Have ideas? Open an issue or PR.
 
-### OpenCode & Codex Support
-
-Currently only Claude Code works natively in Termux. OpenCode and Codex require a full Linux environment (proot-distro), which is too slow for practical use on mobile devices.
+### Tool Support
 
 **Current status:**
 - **Claude Code** - Works natively in Termux
-- **OpenCode** - Requires proot-distro (too slow)
-- **Codex** - Requires proot-distro (too slow)
+- **OpenCode** - Works natively in Termux via the prebuilt aarch64 build
 
-**Possible solutions being explored:**
-- Native ARM builds for Termux
-- Lightweight alternatives that run directly in Termux
-- Performance optimizations for proot-distro
+OpenCode compiles to a standalone binary using [Bun](https://bun.sh/), which
+has no official Android support, so `npm install -g opencode-ai` cannot work
+under Termux. [guysoft/opencode-termux](https://github.com/guysoft/opencode-termux)
+cross-compiles Bun and WebKit/JSC for Android/aarch64 and publishes prebuilt
+packages; Nomacode installs from those automatically when running on Termux.
 
 ### Community Standards
 

--- a/server/api/settings.js
+++ b/server/api/settings.js
@@ -28,9 +28,9 @@ router.put('/', (req, res) => {
     }
 
     if (defaultTool !== undefined) {
-      if (!['claude-code', 'opencode', 'codex', 'bash'].includes(defaultTool)) {
+      if (!['claude-code', 'opencode', 'bash'].includes(defaultTool)) {
         return res.status(400).json({
-          error: 'defaultTool must be "claude-code", "opencode", "codex", or "bash"'
+          error: 'defaultTool must be "claude-code", "opencode", or "bash"'
         });
       }
       updates.defaultTool = defaultTool;

--- a/server/api/tools.js
+++ b/server/api/tools.js
@@ -52,7 +52,7 @@ router.post('/:id/install', (req, res) => {
     return res.status(404).json({ error: 'Unknown tool' });
   }
 
-  if (!info.installCmd) {
+  if (!info.installCmd && !info.installScript) {
     return res.status(400).json({ error: 'Tool cannot be installed' });
   }
 
@@ -64,10 +64,15 @@ router.post('/:id/install', (req, res) => {
     return res.status(409).json({ error: 'Installation already in progress' });
   }
 
-  // Parse install command
-  const parts = info.installCmd.split(' ');
-  const cmd = parts[0];
-  const args = parts.slice(1);
+  // Multi-step installs (download, dpkg, dependency) need a shell; simple
+  // ones stay argv-style so no shell parsing is involved. Both come from the
+  // TOOLS table in tool-detector.js, never from user input.
+  const useScript = !!info.installScript;
+  const cmd = useScript ? 'sh' : info.installCmd.split(' ')[0];
+  const args = useScript
+    ? ['-c', info.installScript]
+    : info.installCmd.split(' ').slice(1);
+  const displayCmd = useScript ? 'OpenCode (Termux aarch64 build)' : info.installCmd;
 
   // Set up SSE for streaming output
   res.setHeader('Content-Type', 'text/event-stream');
@@ -78,7 +83,7 @@ router.post('/:id/install', (req, res) => {
     res.write(`data: ${JSON.stringify({ type, data })}\n\n`);
   };
 
-  sendEvent('start', { tool: toolId, command: info.installCmd });
+  sendEvent('start', { tool: toolId, command: displayCmd });
 
   const proc = spawn(cmd, args, {
     env: { ...process.env, FORCE_COLOR: '0' },

--- a/server/services/pty-manager.js
+++ b/server/services/pty-manager.js
@@ -118,9 +118,6 @@ function createSession(id, options = {}) {
       case 'opencode':
         command = 'opencode';
         break;
-      case 'codex':
-        command = 'codex';
-        break;
       default:
         command = defaultShell;
     }

--- a/server/services/tool-detector.js
+++ b/server/services/tool-detector.js
@@ -1,5 +1,49 @@
 const { execSync } = require('child_process');
 
+// Termux is the primary target and needs different install paths: it is
+// Android/aarch64, so anything requiring Bun can't use the npm package.
+const isTermux = !!process.env.TERMUX_VERSION ||
+  (process.env.PREFIX || '').includes('com.termux');
+
+// OpenCode compiles to a standalone binary via Bun, and Bun has no Android
+// support (upstream marked "not planned"), so `npm install -g opencode-ai`
+// cannot work under Termux. guysoft/opencode-termux cross-compiles Bun and
+// WebKit/JSC for aarch64 and publishes prebuilt packages; use those instead.
+// The .deb asset name embeds the OpenCode version (opencode_1.17.9_aarch64.deb),
+// so there is no stable `releases/latest/download/<name>` URL — the one in the
+// project README 404s. Resolve the real asset from the releases API instead.
+const OPENCODE_TERMUX_INSTALL = [
+  'set -eu',
+  'echo "Installing OpenCode for Termux (aarch64)…"',
+  'pkg install -y ripgrep curl',
+  'api=https://api.github.com/repos/guysoft/opencode-termux/releases/latest',
+  'deb_url=$(curl -fsSL "$api" | grep -o "https://[^\\"]*_aarch64\\.deb" | head -1)',
+  'sums_url=$(curl -fsSL "$api" | grep -o "https://[^\\"]*SHA256SUMS" | head -1)',
+  'if [ -z "$deb_url" ]; then echo "Could not find an aarch64 .deb in the latest release." >&2; exit 1; fi',
+  'tmp=$(mktemp -d)',
+  'trap \'rm -rf "$tmp"\' EXIT',
+  'echo "Downloading $deb_url"',
+  'curl -fL -o "$tmp/opencode.deb" "$deb_url"',
+  // Verify against the published checksums: this is a binary we are about to
+  // install and run. Skipped only if the release has no SHA256SUMS.
+  'if [ -n "$sums_url" ]; then',
+  '  curl -fsSL -o "$tmp/SHA256SUMS" "$sums_url"',
+  '  name=$(basename "$deb_url")',
+  '  want=$(grep " [ *]*$name$" "$tmp/SHA256SUMS" | awk \'{print $1}\' | head -1)',
+  '  if [ -n "$want" ]; then',
+  '    got=$(sha256sum "$tmp/opencode.deb" | awk \'{print $1}\')',
+  '    if [ "$want" != "$got" ]; then echo "Checksum mismatch for $name" >&2; exit 1; fi',
+  '    echo "Checksum OK"',
+  '  else',
+  '    echo "Warning: no checksum listed for $name" >&2',
+  '  fi',
+  'else',
+  '  echo "Warning: release publishes no SHA256SUMS; skipping verification" >&2',
+  'fi',
+  'dpkg -i "$tmp/opencode.deb"',
+  'echo "OpenCode installed."'
+].join('\n');
+
 // Define available tools with their commands and install instructions
 const TOOLS = {
   'claude-code': {
@@ -11,14 +55,12 @@ const TOOLS = {
   'opencode': {
     command: 'opencode',
     name: 'OpenCode',
-    installCmd: 'npm install -g opencode-ai',
+    // On Termux the npm package can't run (no Bun for Android), so install
+    // the prebuilt aarch64 build. installScript needs a shell; installCmd is
+    // a single argv-style command. Exactly one of the two is set.
+    installCmd: isTermux ? null : 'npm install -g opencode-ai',
+    installScript: isTermux ? OPENCODE_TERMUX_INSTALL : null,
     description: 'Open-source AI coding assistant'
-  },
-  'codex': {
-    command: 'codex',
-    name: 'Codex',
-    installCmd: 'npm install -g @openai/codex',
-    description: 'OpenAI Codex CLI'
   },
   'shell': {
     command: null, // Always available
@@ -110,7 +152,9 @@ function detectTools() {
       id,
       name: tool.name,
       description: tool.description,
-      installCmd: tool.installCmd
+      // The UI only needs to know whether an install path exists, not which
+      // mechanism it uses.
+      installCmd: tool.installCmd || (tool.installScript ? 'termux' : null)
     };
 
     if (tool.command === null) {
@@ -134,8 +178,8 @@ function detectTools() {
 
 function getDefaultTool() {
   const { available } = detectTools();
-  // Prefer claude-code, then opencode, then codex, then shell
-  const priority = ['claude-code', 'opencode', 'codex', 'shell'];
+  // Prefer claude-code, then opencode, then shell
+  const priority = ['claude-code', 'opencode', 'shell'];
 
   for (const id of priority) {
     if (available.find(t => t.id === id)) {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -823,41 +823,6 @@ body:has(#key-toolbar.visible) #statusbar {
   background: var(--accent-dim);
 }
 
-/* Coming soon hint */
-.coming-soon-hint {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  background: var(--surface);
-  border-radius: 4px;
-  font-size: 12px;
-}
-
-.coming-soon-hint .hint-name {
-  color: var(--text-dim);
-}
-
-.coming-soon-badge {
-  padding: 2px 6px;
-  background: var(--border);
-  border-radius: 3px;
-  color: var(--text-dim);
-  font-size: 10px;
-  text-transform: uppercase;
-}
-
-.coming-soon-link {
-  margin-left: auto;
-  color: var(--accent);
-  font-size: 11px;
-  text-decoration: none;
-}
-
-.coming-soon-link:hover {
-  text-decoration: underline;
-}
-
 /* Profile items in settings */
 .profiles-list {
   display: flex;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1091,10 +1091,9 @@ class Nomacode {
       `<option value="${t.id}">${this.escapeHtml(t.name)}</option>`
     ).join('');
 
-    // Build unavailable tools with install buttons (exclude coming soon tools)
-    const comingSoonIds = ['codex'];
+    // Build unavailable tools with install buttons
     let unavailableHint = '';
-    const installableTools = (this.tools?.unavailable || []).filter(t => !comingSoonIds.includes(t.id));
+    const installableTools = this.tools?.unavailable || [];
     if (installableTools.length > 0) {
       const hints = installableTools.map(t =>
         `<div class="install-hint">
@@ -1105,23 +1104,6 @@ class Nomacode {
       unavailableHint = `
         <div class="form-group">
           <label class="form-label form-label-muted">Install AI tools:</label>
-          ${hints}
-        </div>
-      `;
-    }
-
-    // Show coming soon tools (if not available)
-    let comingSoonHint = '';
-    const comingSoonTools = (this.tools?.unavailable || []).filter(t => comingSoonIds.includes(t.id));
-    if (comingSoonTools.length > 0) {
-      const hints = comingSoonTools.map(t =>
-        `<div class="coming-soon-hint">
-          <span class="hint-name">${this.escapeHtml(t.name)}</span>
-          <span class="coming-soon-badge">Coming soon</span>
-        </div>`
-      ).join('');
-      comingSoonHint = `
-        <div class="form-group">
           ${hints}
         </div>
       `;
@@ -1153,7 +1135,6 @@ class Nomacode {
         </select>
       </div>
       ${unavailableHint}
-      ${comingSoonHint}
       <div class="form-actions">
         <button class="btn" onclick="app.hideModal()">Cancel</button>
         <button class="btn btn-primary" onclick="app.submitNewSession()">Start</button>


### PR DESCRIPTION
Closes the last item of the fork/queue review: wire up [guysoft/opencode-termux](https://github.com/guysoft/opencode-termux) and strip Codex.

## OpenCode on Termux

Our install command was `npm install -g opencode-ai`, which **cannot work on Termux at all**. OpenCode compiles to a standalone binary via [Bun](https://bun.sh/), and Bun has no Android support — upstream marked it [not planned](https://github.com/oven-sh/bun/issues/9). So the one platform Nomacode primarily targets was the one where that install was guaranteed to fail.

`guysoft/opencode-termux` exists precisely for this: it cross-compiles Bun *and* WebKit/JavaScriptCore for Android/aarch64 and publishes prebuilt packages. It's a build system, not a library — so the integration is an install path, not vendored code.

- Termux → download and `dpkg -i` the prebuilt aarch64 `.deb`
- Everywhere else → unchanged `npm install -g opencode-ai`

**Termux detection** (`TERMUX_VERSION` / `$PREFIX`) did not exist anywhere in the codebase, despite Termux being the primary target. Added.

**Install mechanism.** The installer used `spawn(cmd, args)` with no shell, so only a single command was possible. The Termux install needs several steps (dependency, download, verify, install), so tools may now define `installScript` (run via `sh -c`) as an alternative to `installCmd` (argv-style). Both come from the `TOOLS` table, never from user input.

## Two problems found while implementing

**1. The documented URL 404s.** The project README says to fetch:

```
releases/latest/download/opencode-aarch64.deb
```

but the real asset embeds the OpenCode version — `opencode_1.17.9_aarch64.deb` — so there is no stable `latest/download` name:

```
404  https://github.com/.../releases/download/v0.2.1/opencode-aarch64.deb
```

Resolved via the releases API instead, which returns the correct URL.

**2. No integrity check.** We download a 49MB binary and then install and execute it. The release publishes `SHA256SUMS`, so the script now verifies against it and aborts on mismatch. Verified end-to-end against the real release:

```
want: 8d5dec3eca5e087df6fddc30d86dda58be4029b866d55e71bb10eb209d5eb6f5
got : 8d5dec3eca5e087df6fddc30d86dda58be4029b866d55e71bb10eb209d5eb6f5
CHECKSUM VERIFIED    size: 49876660 bytes
```

If a future release drops `SHA256SUMS`, the install warns and proceeds rather than breaking — worth revisiting if that ever happens.

## Codex removal

Removed from the tool table, session launcher (`pty-manager.js`), settings validation, default-tool priority list, and the new-session UI. Codex was the only "coming soon" tool, so that mechanism and its CSS are gone as well.

Docs updated: the README stated OpenCode "requires proot-distro (too slow)" and cannot run natively on Termux, which this change makes untrue.

## Verification

```
tools: [ 'claude-code', 'opencode', 'shell' ]
codex present: false
default tool: claude-code

--- non-Termux ---              --- Termux (simulated) ---
PASS non-termux -> npm          PASS termux -> sh -c
PASS args parsed                PASS script is non-empty
PASS no installScript           PASS no installCmd on termux
PASS codex removed              PASS codex removed
```

URL resolution and checksum verification were run against the live GitHub API and the real 49MB artifact.

## Not verified

The install itself has not been run on a device — `pkg`, `dpkg` and an aarch64 target don't exist here, so the Termux branch was exercised by simulating `TERMUX_VERSION` and testing the download/verify steps in isolation. The actual `dpkg -i` needs a real device.